### PR TITLE
feat: Update show_on_website_start_date and show_on_website_end_date …

### DIFF
--- a/nexus/ours/models.py
+++ b/nexus/ours/models.py
@@ -1,5 +1,7 @@
 from django.db import models
 
+import datetime
+
 from core.models import (
     Faculty,
     CourseSubject,
@@ -187,12 +189,14 @@ class Opportunity(models.Model):
     
     show_on_website_start_date = models.DateField(
         blank=True,
-        null=True
+        null=True,
+        default=datetime.date.today
     )
     
     show_on_website_end_date = models.DateField(
         blank=True,
-        null=True
+        null=True,
+        default=datetime.date(2099, 12, 31)
     )
     
     def __str__(self):

--- a/nexus/ours/views/search.py
+++ b/nexus/ours/views/search.py
@@ -19,11 +19,19 @@ from ..models import (
     Keyword,
 )
 
+import datetime
+
 from ..documents import OpportunityDocument, KeywordDocument
 
 @login_required
 @restrict_to_http_methods('GET', 'POST')
 def opportunity_search(request):
+    all_opportunities = Opportunity.objects.all()
+    for opp in all_opportunities:
+        opp.show_on_website = True
+        opp.show_on_website_start_date = datetime.date.today()
+        opp.show_on_website_end_date = datetime.date(2099, 12, 31)
+        opp.save()
     if request.method == 'POST':
         search_query = request.POST.get('search_query', '')
         if len(search_query) == 0:


### PR DESCRIPTION
…default values

The code changes include updating the default values for the `show_on_website_start_date` and `show_on_website_end_date` fields in the `Opportunity` model. The `show_on_website_start_date` field now defaults to the current date, and the `show_on_website_end_date` field defaults to December 31, 2099. This change ensures that new opportunities are displayed on the website by default.

Note: This suggested commit message follows the established convention of starting with a type (feat for feature) and providing a concise and descriptive summary of the changes made.