### PR TITLE
Made changes for prod execution

### DIFF
--- a/nexus/Dockerfile.prod
+++ b/nexus/Dockerfile.prod
@@ -1,0 +1,67 @@
+###########
+# BUILDER #
+###########
+
+# pull official base image
+FROM python:3.13.1-slim as builder
+
+# set work directory
+WORKDIR /usr/src/app
+
+# set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# install system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gcc
+
+# lint
+RUN pip install --upgrade pip
+COPY . /usr/src/app/
+
+# install python dependencies
+COPY ./requirements.txt .
+RUN pip wheel --no-cache-dir --no-deps --wheel-dir /usr/src/app/wheels -r requirements.txt
+
+
+#########
+# FINAL #
+#########
+
+# pull official base image
+FROM python:3.13.1-slim
+
+# create directory for the app user
+RUN mkdir -p /home/app
+
+# create the app user
+RUN addgroup --system app && adduser --system --group app
+
+# create the appropriate directories
+ENV HOME=/home/app
+ENV APP_HOME=/home/app/web
+RUN mkdir $APP_HOME
+RUN mkdir $APP_HOME/staticfiles
+WORKDIR $APP_HOME
+
+# install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends curl
+COPY --from=builder /usr/src/app/wheels /wheels
+COPY --from=builder /usr/src/app/requirements.txt .
+RUN pip install --upgrade pip
+RUN pip install --no-cache /wheels/*
+
+# copy entrypoint.prod.sh
+COPY ./entrypoint.prod.sh .
+RUN sed -i 's/\r$//g'  $APP_HOME/entrypoint.prod.sh
+
+# copy project
+COPY . $APP_HOME
+RUN chown -R app:app $APP_HOME && chmod +x $APP_HOME/entrypoint.prod.sh
+
+# change to the app user
+USER app
+
+# run entrypoint.prod.sh
+ENTRYPOINT ["/home/app/web/entrypoint.prod.sh"]

--- a/nexus/entrypoint.prod.sh
+++ b/nexus/entrypoint.prod.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Wait for Elasticsearch to be ready
+echo "Waiting for Elasticsearch..."
+while ! curl -s http://es-nexus:9200 >/dev/null; do
+  sleep 3
+done
+
+echo "Elasticsearch is up! Running migrations, collecting static files, and indexing..."
+python manage.py migrate --noinput
+python manage.py collectstatic --noinput
+python manage.py search_index --rebuild -f
+
+echo "Starting Django..."
+exec "$@"

--- a/nexus/nexus/settings.py
+++ b/nexus/nexus/settings.py
@@ -179,7 +179,7 @@ USE_TZ = True
 
 STATIC_URL = "static/"
 
-STATIC_ROOT = "/srv/static/"
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field


### PR DESCRIPTION
This pull request introduces a new production-ready Docker setup for the `nexus` project, including a multi-stage Dockerfile and an entrypoint script. Additionally, it modifies the static files directory configuration in the Django settings.

**Docker setup:**

* [`nexus/Dockerfile.prod`](diffhunk://#diff-cdac553a3da25a084d3abeffe58483ca3817454061a85a56dfc2081063e9d1b4R1-R67): Added a multi-stage Dockerfile for building and running the application, including setting up environment variables, installing dependencies, and configuring the application user and directories.
* [`nexus/entrypoint.prod.sh`](diffhunk://#diff-bef0418359104db3771fd7509144384334daa4eeb654ce36f895bba658f3f009R1-R15): Added an entrypoint script to wait for Elasticsearch to be ready, run Django migrations, collect static files, and rebuild the search index before starting the Django application.

**Django settings:**

* [`nexus/nexus/settings.py`](diffhunk://#diff-1d67889e963cfa59e48b24cd7cd2a8174e70317a5072d08a255c05d033919ec8L182-R182): Changed the `STATIC_ROOT` setting to use a directory within the project base directory for static files.